### PR TITLE
feat(practice): add popover, accordion, toggle, and permutation components

### DIFF
--- a/packages/react-testing/src/components/ReactTutorial-Frontend-Master/Accordion/AccordionWrapper.jsx
+++ b/packages/react-testing/src/components/ReactTutorial-Frontend-Master/Accordion/AccordionWrapper.jsx
@@ -1,0 +1,29 @@
+import React, { useState } from "react";
+import './accordion.css';
+
+export default function AccordionWrapper() {
+    return <Accordion heading="Accordion Title">
+        <h1>Content!!</h1>
+    </Accordion>;
+}
+
+function Accordion({ heading, children }) {
+    const [isOpen, setIsOpen] = useState(false);
+    const contentClasses = `accordion-content ${isOpen ? "": "disabled"}`;
+
+    const handleAccordionToggle = () => {
+        setIsOpen((prev) => !prev);
+    };
+
+    return (
+        <div data-expanded={isOpen} className="accordion">
+            <button aria-controls="panel" aria-expanded={isOpen} onClick={handleAccordionToggle} className="accordion-heading">
+                <h2>
+                    THis is the heading
+                </h2>
+                {heading}
+            </button>
+            <div id="panel" className={contentClasses} aria-hidden={!isOpen}>{children}</div>
+        </div>
+    );
+}

--- a/packages/react-testing/src/components/ReactTutorial-Frontend-Master/Accordion/accordion.css
+++ b/packages/react-testing/src/components/ReactTutorial-Frontend-Master/Accordion/accordion.css
@@ -1,0 +1,32 @@
+.accordion  {
+    width: 100%;
+    /* position: relative; */
+    /* border: 1px solid gainsboro; */
+    width: 80vw;
+    height: 96px;
+    overflow: hidden;
+    transition: height 0.3s ease-in;
+}
+
+.accordion .accordion-heading {
+    /* border: 1px solid orange; */
+    background-color: lightcoral;
+    border-radius: 10px;;
+    padding: 1rem;
+    height: 96px;;
+    width: 100%;
+}
+
+.accordion-heading:focus-visible {
+    outline: 20px solid blue;
+}
+
+.accordion .accordion-content {
+    padding: 1rem;
+    background-color: beige;
+    border-radius: 10px;
+}
+
+.accordion[data-expanded="true"] {
+    height: 300px;
+}

--- a/packages/react-testing/src/components/ReactTutorial-Frontend-Master/Accordion/index.js
+++ b/packages/react-testing/src/components/ReactTutorial-Frontend-Master/Accordion/index.js
@@ -1,0 +1,1 @@
+export { default } from './AccordionWrapper';

--- a/packages/react-testing/src/components/ReactTutorial-Frontend-Master/Practice/Popover/Popover.jsx
+++ b/packages/react-testing/src/components/ReactTutorial-Frontend-Master/Practice/Popover/Popover.jsx
@@ -38,7 +38,6 @@ function Content({ children, contentRef }) {
 }
 
 function Popover({ children }) {
-   
     return (
          <div className="popover">{children}</div>
     );

--- a/packages/react-testing/src/components/ReactTutorial-Frontend-Master/Practice/Popover/PopoverHTMLApi.jsx
+++ b/packages/react-testing/src/components/ReactTutorial-Frontend-Master/Practice/Popover/PopoverHTMLApi.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import './popover-html.css';
+
+function PopoverHTMLApi() {
+    return (
+        <div>
+            <div className="popover-trigger">
+                <button popovertarget="myPopover">Click me!</button>
+            </div>
+            <div className="popover-content" popover="auto" id="myPopover">
+                Popover
+                <h1>Popover Content</h1>
+                <button popovertargetaction="hide" popovertarget="myPopover">
+                    Close Popover
+                </button>
+            </div>
+        </div>
+    );
+}
+
+export default PopoverHTMLApi;

--- a/packages/react-testing/src/components/ReactTutorial-Frontend-Master/Practice/Popover/index.js
+++ b/packages/react-testing/src/components/ReactTutorial-Frontend-Master/Practice/Popover/index.js
@@ -1,1 +1,1 @@
-export { default } from './Popover';
+export { default } from './PopoverHTMLApi.jsx';

--- a/packages/react-testing/src/components/ReactTutorial-Frontend-Master/Practice/Popover/popover-html.css
+++ b/packages/react-testing/src/components/ReactTutorial-Frontend-Master/Practice/Popover/popover-html.css
@@ -1,0 +1,3 @@
+.popover-content {
+    background-color: gold;
+}

--- a/packages/react-testing/src/components/ReactTutorial-Frontend-Master/Practice/Toggle/Toggle.jsx
+++ b/packages/react-testing/src/components/ReactTutorial-Frontend-Master/Practice/Toggle/Toggle.jsx
@@ -1,0 +1,26 @@
+import React, { useEffect, useRef, useState } from 'react'
+import './toggle.css';
+
+function Toggle({ isOn, onToggle }) {
+
+    const handleChange = (e) => {
+        const checked = e.target.checked;
+        onToggle(checked);
+    } 
+    return (
+        <label className='switch'>
+                <input type="checkbox" id="myCheckbox" role="switch" aria-checked={isOn} onChange={handleChange} />
+                <span className='switch-toggle' />
+                <span className='switch-label'>Do you consent ?</span>
+        </label>
+    )
+}
+
+export default function ToggleWrapper() {
+    const [isOn, setIsOn] = useState(false);
+    const onToggle = () => {
+        setIsOn((prev) => !prev);
+    }
+
+    return <Toggle isOn={isOn} onToggle={onToggle} />
+}

--- a/packages/react-testing/src/components/ReactTutorial-Frontend-Master/Practice/Toggle/index.js
+++ b/packages/react-testing/src/components/ReactTutorial-Frontend-Master/Practice/Toggle/index.js
@@ -1,0 +1,1 @@
+export { default } from './Toggle';

--- a/packages/react-testing/src/components/ReactTutorial-Frontend-Master/Practice/Toggle/toggle.css
+++ b/packages/react-testing/src/components/ReactTutorial-Frontend-Master/Practice/Toggle/toggle.css
@@ -1,0 +1,46 @@
+.switch input[type="checkbox"] {
+    opacity: 0;
+}
+
+.switch {
+    position: relative;
+    height: 22px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    width: 100%;
+}
+
+.switch .switch-toggle {
+    /* position: absolute; */
+    left: 0;
+    top: 0;
+    width: 50px;
+    height: 100%;
+    border: 1px solid black;
+    border-radius: 20px;
+}
+
+.switch-toggle::before {
+    content: "";
+    width: 20px;
+    height: 20px;
+    position: absolute;
+    left: 23px;
+    top: 1px;
+    border-radius: 100px;
+    background-color: grey;
+}
+
+.switch:has(input:checked) .switch-toggle::before {
+    transform: translate(26px);
+    background-color: red;;
+}
+
+.switch-label {
+    margin-left: 0.5rem;
+}
+
+.switch:has(input:checked) .switch-toggle {
+    outline: 3px solid blue;
+}

--- a/packages/react-testing/src/components/ReactTutorial-Frontend-Master/Tutorial.jsx
+++ b/packages/react-testing/src/components/ReactTutorial-Frontend-Master/Tutorial.jsx
@@ -3,7 +3,9 @@ import React, { useState } from "react";
 // import OtpWrapper from "./Practice/Otp";
 // import Virtualisation from "./Practice/Virtualisation";
 // import Inf from "./Practice/InfiniteScroll";
-import Popover from "./Practice/Popover";
+// import Popover from "./Practice/Popover";
+// import Toggle from "./Practice/Toggle";
+import AccordionWrapper from "./Accordion";
 
 function debounce(fn, delay) {
     let timeoutId = null;
@@ -38,8 +40,9 @@ function Tutorial(props) {
 
     return (
         <>
-        <Popover />
-            {/* input */}
+
+            <div>Input</div>
+            <AccordionWrapper />
             {/* <div>
                 <input type="text" value={search} onChange={handleChange} />
             </div>

--- a/packages/react-testing/src/components/indexedDB/index.html
+++ b/packages/react-testing/src/components/indexedDB/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+<body>
+    
+    <h1>Hello</h1>
+
+    <script src="./indexed.js"></script>
+</body>
+</html>

--- a/packages/react-testing/src/components/indexedDB/indexed.js
+++ b/packages/react-testing/src/components/indexedDB/indexed.js
@@ -1,0 +1,1 @@
+console.log("Testing indexed DB");

--- a/packages/react-testing/src/components/polyfills/README.md
+++ b/packages/react-testing/src/components/polyfills/README.md
@@ -1,0 +1,330 @@
+# JavaScript Polyfills & Internals — Revision Notes
+
+Quick-revision guide for every file in this folder. Grouped by theme. Each entry gives the **concept**, the **implementation strategy**, and **gotchas / interview points** so you can recall the approach fast.
+
+> These files re-implement built-in JS features from scratch (polyfills) plus a few browser-internals demos (event loop, web workers, AbortController). Great for frontend interview prep.
+
+---
+
+## Contents
+
+**Array method polyfills**
+1. [`Array.prototype.map`](#1-arrayprototypemap) — `polyfill-map.js`, `polyfill-map1.js`, `polyfill-map-final.js`
+2. [`Array.prototype.filter`](#2-arrayprototypefilter) — `polyfill-filter-1.js`
+3. [`Array.prototype.reduce`](#3-arrayprototypereduce) — `polyfill-reduce.js`
+4. [`Array.prototype.slice`](#4-arrayprototypeslice) — `polyfill-slice.js`
+5. [`Array.prototype.flat`](#5-arrayprototypeflat) — `polyfill-array-flat.js`
+
+**Function / object internals**
+6. [`Function.prototype.bind`](#6-functionprototypebind) — `polyfill-bind.js`
+7. [`Function.prototype.call`](#7-functionprototypecall) — `polyfill-call.js` (stub)
+8. [`new` operator](#8-new-operator) — `polyfill-new.js`
+9. [`Object.create`](#9-objectcreate) — `polyfill-object-create.js`
+10. [`this` binding / `Timer`](#10-this-binding--timer) — `functions.js`
+
+**Timers**
+11. [`setTimeout`](#11-settimeout) — `polyfill-setTimeout.js`
+12. [`setInterval`](#12-setinterval) — `polyfill-setInterval.js`
+
+**Promises**
+13. [Promise polyfill (full)](#13-promise-polyfill-full) — `promises-polyfill.js`
+14. [Promise polyfill (basic)](#14-promise-polyfill-basic) — `interview-prep.js`
+15. [Native promise chaining demo](#15-native-promise-chaining-demo) — `test.js`
+
+**Async control & concurrency**
+16. [AbortController + cancellable promise](#16-abortcontroller--cancellable-promise) — `abort-controller.js`, `abort-controller1.js`
+17. [Debounce](#17-debounce) — `polyfill-debounce.js`
+18. [Event loop / `requestAnimationFrame`](#18-event-loop--requestanimationframe) — `polyfill-event-loop.js`
+19. [Web Workers](#19-web-workers) — `worker.js`, `workers-practical.js`
+
+**Harness**
+20. [`index.html`](#20-indexhtml) — the runner page
+
+---
+
+## Array method polyfills
+
+### 1. `Array.prototype.map`
+**Files:** `polyfill-map.js` (v1), `polyfill-map1.js` (v2, standalone), `polyfill-map-final.js` (v3, final)
+
+**Concept:** `map` returns a new array where each element is transformed by a callback.
+
+**Strategy across the three versions:**
+- **v1 (`polyfill-map.js`)** — simplest: create `newArr`, `forEach` over `this`, push `cb(item)`. Attached as `customMap`.
+- **v2 (`polyfill-map1.js`)** — standalone `myMap(arr, cb, thisArg)`; calls `cb.call(thisArg, item, i, arr)` to pass **all three** map args (item, index, array) and honour `thisArg`. Works on array-like objects (`{length, 0, 1}`).
+- **v3 (`polyfill-map-final.js`)** — the "correct" version: pre-sizes `new Array(this.length)`, walks with a `while` loop, and uses `Object.hasOwn(this, k)` to **skip holes in sparse arrays** (preserving index positions). Invoked via `.call` on an array-like.
+
+**Interview points:**
+- Real `map` preserves sparse holes → the `Object.hasOwn` guard.
+- Callback receives `(value, index, array)`.
+- Result length equals source length.
+
+---
+
+### 2. `Array.prototype.filter`
+**File:** `polyfill-filter-1.js`
+
+**Concept:** Return a new array containing only elements for which the callback is truthy.
+
+**Strategy:** `while` loop over indices; `Object.hasOwn(this, k)` skips sparse holes; push `this[k]` only when `callbackFn(this[k])` is truthy.
+
+**Interview point:** Demonstrated on a sparse array `[1,2,3,,4,,,5]` → holes are ignored, not treated as `undefined`.
+
+---
+
+### 3. `Array.prototype.reduce`
+**File:** `polyfill-reduce.js`
+
+**Concept:** Fold an array into a single accumulated value.
+
+**Strategy:**
+- Throw on empty array (matches native behaviour when no init value).
+- If `init` given → start acc = `init`, index 0. Else → start acc = `this[0]`, index 1.
+- Loop, `reducedValue = callbackFn(reducedValue, this[k])`, skipping sparse holes with `Object.hasOwn`.
+
+**Gotcha (bug to note):** `const initialValue = init || this[0]` uses `||`, so a **falsy valid init** like `0` or `""` is wrongly ignored. Native uses `arguments.length` to detect whether init was passed. Worth fixing for correctness.
+
+---
+
+### 4. `Array.prototype.slice`
+**File:** `polyfill-slice.js`
+
+**Concept:** Return a shallow copy of a portion `[start, end)`; supports negative indices.
+
+**Strategy:**
+- Default `end` to length; clamp `end` to length if too large.
+- Normalise negative `start`/`end` by adding `length` until non-negative.
+- Copy `[start, end)` into a new array, skipping sparse holes.
+
+**Gotchas:**
+- `if(!startIndex && !endIndex)` treats `slice(0)` as "no args" because `0` is falsy — edge case bug.
+- `startIndex % arrLength` is a non-standard twist; native `slice` clamps rather than wraps with modulo.
+
+---
+
+### 5. `Array.prototype.flat`
+**File:** `polyfill-array-flat.js`
+
+**Concept:** Flatten a nested array up to a given `depth` (default effectively infinite here = 100).
+
+**Strategy:** **Recursion.** For each item: if it's an array and `depth > 0`, recurse with `depth-1` and spread the result; else push the item as-is.
+
+**Bonus trick (in comments):** `arr.toString().split(",").map(Number)` fully flattens — but it stringifies everything and loses types, so it only works for clean numeric arrays.
+
+---
+
+## Function / object internals
+
+### 6. `Function.prototype.bind`
+**File:** `polyfill-bind.js`
+
+**Concept:** `bind` returns a new function permanently bound to a given `this` and preset args.
+
+**Strategy:** `myBind(thisArg, ...args)` returns a closure that calls the original function with `thisArg`.
+
+**Gotcha (bug):** The returned function uses `this.call(...)` — it should be `self.call(thisArg, ...args)` where `self = this` (the original function). As written, `this` inside the returned function isn't the bound function. Also it doesn't `return` the result or merge later-passed args. Good "spot the bug" example.
+
+---
+
+### 7. `Function.prototype.call`
+**File:** `polyfill-call.js`
+
+**Status:** **Stub / near-empty** (single line). Intended to implement `call` by attaching the function as a temporary property on `thisArg`, invoking it, then deleting it. Not yet implemented.
+
+---
+
+### 8. `new` operator
+**File:** `polyfill-new.js`
+
+**Concept:** Replicate what `new Constructor(...args)` does under the hood.
+
+**Strategy (`myNew`):**
+1. Create a fresh empty object.
+2. Build a prototype object carrying `constructor` + all keys copied from `Constructor.prototype`.
+3. `Object.setPrototypeOf(obj, proto)` to wire the prototype chain.
+4. `Constructor.call(obj, ...args)` to run the constructor with `this = obj`.
+5. Return the object.
+
+**Interview points:** The four things `new` does — create object, link prototype, bind `this`, return object (unless the constructor returns its own object). *(Simpler idiomatic version: `Object.create(Constructor.prototype)` instead of copying keys manually.)*
+
+---
+
+### 9. `Object.create`
+**File:** `polyfill-object-create.js`
+
+**Concept:** Create a new object with a specified prototype and optional property descriptors.
+
+**Strategy (`myCreate`):** New object → `Object.defineProperties(newObj, properties)` for the descriptor map → `Object.setPrototypeOf(newObj, proto)`.
+
+**Interview point:** Second arg uses **property descriptors** (`{ value, writable, enumerable, configurable }`), not plain values — hence `{ newValue: { value: "Abcd" } }`.
+
+---
+
+### 10. `this` binding / `Timer`
+**File:** `functions.js`
+
+**Concept:** Demonstrates arrow-function `this` capture inside a constructor + prototype method.
+
+**Strategy:** `Timer` increments `this.seconds` in a `setInterval`; `getSeconds` is defined as an **arrow** on the prototype so it captures the enclosing `this`. An outer interval logs the value every 4s.
+
+**Interview point:** Arrow functions don't get their own `this` → they inherit it lexically. That's why the arrow-based `getSeconds` correctly sees the instance's `seconds`.
+
+---
+
+## Timers
+
+### 11. `setTimeout`
+**File:** `polyfill-setTimeout.js`
+
+**Concept:** Re-implement `setTimeout` / `clearTimeout` without using the native timer.
+
+**Strategy:**
+- Maintain a global `window.timeouts` queue of `{ id, exec, args, interval, timeToRun }`.
+- `mySetTimeout` assigns an incrementing id, computes `timeToRun = Date.now() + interval`, pushes, and starts polling.
+- `runCallbacks` checks each entry: if `Date.now() >= timeToRun` → execute + clear it; else re-schedule the poll via `requestIdleCallback`.
+- `clearMyTimeout(id)` filters the entry out of the queue.
+
+**Interview point:** Shows that timers are just a **task queue polled against the clock** — the browser fires callbacks when due, not exactly on time.
+
+---
+
+### 12. `setInterval`
+**File:** `polyfill-setInterval.js`
+
+**Concept:** Same idea as above but the callback re-arms itself repeatedly.
+
+**Strategy:** Store interval descriptors; `runCallback` fires `exec` when due, resets `timeToRun = Date.now() + interval`, and re-schedules itself via `requestIdleCallback` so it keeps looping. `myClearInterval(id)` removes it from `window.myIntervals`.
+
+**Gotcha (bug):** Typos mix `window.myIntervals` and `window.myIntevals` (missing `r`), so the store isn't consistent — note this if reusing.
+
+---
+
+## Promises
+
+### 13. Promise polyfill (full)
+**File:** `promises-polyfill.js` — **the most complete implementation**
+
+**Concept:** A spec-flavoured `MyPromise` with proper states, microtask scheduling, and chaining.
+
+**Strategy:**
+- Private fields: `#value`, `#state` (`pending → resolved | rejected`), `#thenCbs`, `#catchcbs`.
+- Constructor runs the executor in a `try/catch`; a throw triggers `#onFail`.
+- `#onSuccess` / `#onFail` are **state-guarded** (only transition from `pending`) — a promise settles once.
+- `#runCallbacks` flushes queued callbacks inside **`queueMicrotask`** → mirrors real async timing (microtask queue).
+- `then` returns a **new MyPromise**, wiring the child's resolve to `thenCb(value)`'s result → enables chaining.
+- `catch` = `then(undefined, catchCb)`.
+- Static `MyPromise.resolve` / `MyPromise.reject`.
+
+**Interview points:** three states + one-way transition, microtask semantics, and `then` returning a new promise for chaining.
+
+---
+
+### 14. Promise polyfill (basic)
+**File:** `interview-prep.js`
+
+**Concept:** A minimal, synchronous first-cut `MyPromise` — the "explain the idea" version.
+
+**Strategy:** Stores `thenCallbacks` / `catchCallbacks`; `resolve` stores the value and invokes queued `then` callbacks; `then` registers a callback then calls `resolve()`.
+
+**Limitations vs the full version (good to articulate):** no state machine, no microtask (runs synchronously), no chaining, `then` before `resolve` timing is fragile. This is the file `index.html` currently loads.
+
+---
+
+### 15. Native promise chaining demo
+**File:** `test.js`
+
+**Concept:** Baseline sanity check using the **real** `Promise` to show `.then` chaining and value propagation (`return 1` flows into the next `.then`). Reference for what the polyfills should reproduce.
+
+---
+
+## Async control & concurrency
+
+### 16. AbortController + cancellable promise
+**Files:** `abort-controller.js`, `abort-controller1.js`
+
+**Concept:** Cancel an in-flight async operation using the standard `AbortController` / `AbortSignal`.
+
+**Strategy:**
+- `abort-controller.js` — wraps a `setTimeout` in a promise; if `signal.aborted` already, reject immediately; otherwise listen for the `"abort"` event → `clearTimeout` + reject. Calling `controller.abort()` cancels it.
+- `abort-controller1.js` — practical `fetch(url, { signal })` demo; passing the signal lets an outstanding request be aborted.
+
+**Interview points:** `signal.aborted`, the `"abort"` event, and passing `signal` into `fetch`. *(Bug in `abort-controller1.js`: `data = data` is self-assignment — the outer `data` never gets set due to shadowing.)*
+
+---
+
+### 17. Debounce
+**File:** `polyfill-debounce.js`
+
+**Concept:** Delay running a function until input stops for `interval` ms — classic search-box optimisation.
+
+**Strategy:** Closure holds a `timeoutId`; each call `clearTimeout`s the previous one and schedules a fresh `setTimeout`. Only the last call within the window actually fires.
+
+**Interview point:** Debounce (wait for a pause) vs throttle (run at most once per interval) — know the difference. Wired to an input's `"input"` event here.
+
+---
+
+### 18. Event loop / `requestAnimationFrame`
+**File:** `polyfill-event-loop.js`
+
+**Concept:** Demonstrates paint timing / event-loop ordering.
+
+**Strategy:** Sets `box` color red → schedules a `requestAnimationFrame` to set it black → immediately sets it blue. Because synchronous code runs first and only the **final** style before paint matters, the box renders **blue**; the rAF callback (black) runs before the next repaint.
+
+**Interview point:** Synchronous code → microtasks → rAF (just before paint) → paint. The browser only paints the last committed style per frame.
+
+---
+
+### 19. Web Workers
+**Files:** `worker.js` (the worker), `workers-practical.js` (main thread)
+
+**Concept:** Run a heavy CPU computation off the main thread so the UI stays responsive.
+
+**Strategy:**
+- `worker.js` — `self.onmessage` runs a huge loop (`17^8` iterations) then `postMessage`s the result.
+- `workers-practical.js` — creates the worker, wires two buttons: one toggles a body class (proves the UI is **not blocked** while the worker computes), one posts a message to start the computation; `worker.onmessage` appends the result to the DOM.
+
+**Interview points:** Workers run in a separate thread, communicate via `postMessage` / `onmessage` (structured-clone, no shared memory by default), and can't touch the DOM directly.
+
+---
+
+## Harness
+
+### 20. `index.html`
+The runner page. Contains a `#box` element (used by the event-loop demo) and loads **`interview-prep.js`** via `<script>`. Swap the `src` to run a different file in the browser (e.g. uncomment the `polyfill-event-loop.js` line, or point it at `promises-polyfill.js`).
+
+---
+
+## Quick Recall Cheat-Sheet
+
+| File | Re-implements | Key trick |
+|---|---|---|
+| `polyfill-map*.js` | `Array.map` | new array, `cb(value,i,arr)`, skip holes |
+| `polyfill-filter-1.js` | `Array.filter` | push when `cb` truthy, skip holes |
+| `polyfill-reduce.js` | `Array.reduce` | acc + init handling (watch `||` bug) |
+| `polyfill-slice.js` | `Array.slice` | negative-index normalisation |
+| `polyfill-array-flat.js` | `Array.flat` | recursion with `depth-1` |
+| `polyfill-bind.js` | `Function.bind` | return closure (has `self`/`this` bug) |
+| `polyfill-new.js` | `new` | create → link proto → `call` → return |
+| `polyfill-object-create.js` | `Object.create` | `defineProperties` + `setPrototypeOf` |
+| `polyfill-setTimeout.js` | `setTimeout` | queue polled vs `Date.now()` |
+| `polyfill-setInterval.js` | `setInterval` | self-rearming poll loop |
+| `promises-polyfill.js` | `Promise` (full) | states + `queueMicrotask` + chaining |
+| `interview-prep.js` | `Promise` (basic) | callback arrays, synchronous |
+| `abort-controller*.js` | cancellation | `signal` + `"abort"` event |
+| `polyfill-debounce.js` | debounce | clear + reschedule timer |
+| `polyfill-event-loop.js` | paint timing | rAF vs sync style writes |
+| `worker.js` / `workers-practical.js` | Web Workers | `postMessage` / `onmessage` |
+
+---
+
+## Recurring Patterns to Remember
+- **Skip sparse holes** with `Object.hasOwn(this, k)` in every array polyfill.
+- **Attach to prototype** (`Array.prototype.x = fn`) so it's callable as a method; use `.call(arrayLike, …)` to run on array-likes.
+- **Prototype chain** = `Object.setPrototypeOf` / `Object.create` — the backbone of `new` and `Object.create`.
+- **Timers = task queues** polled against `Date.now()`; the callback fires when due, never exactly on time.
+- **Promises** = state machine (`pending → settled once`) + **microtask** scheduling + `then` returns a new promise (chaining).
+- **Off-main-thread** work → Web Workers; **debounce/throttle** → tame high-frequency events; **AbortController** → cancel async work.
+
+> ⚠️ Several files contain deliberate/known bugs (noted inline above: `reduce` `||`, `bind` `this` vs `self`, `setInterval` typo, `abort-controller1` self-assignment). Keep these in mind — they're common interview "spot the bug" traps rather than reference-quality code.
+
+**Empty / not covered:** `polyfill-string-to-object.js` is empty (0 bytes) and `polyfill-call.js` is an unfinished stub.

--- a/packages/react-testing/src/components/polyfills/abort-controller.js
+++ b/packages/react-testing/src/components/polyfills/abort-controller.js
@@ -1,3 +1,5 @@
+// The commented block below is the original reference implementation kept for
+// study — it shows a cancellable promise driven by an AbortController signal.
 // function cancelablePromise(signal) {
 //   return new Promise((resolve, reject) => {
 //     // Handle already-aborted signal
@@ -30,10 +32,22 @@
 
 // controller.abort();
 
+/**
+ * cancellablePromise(signal)
+ * Wraps a long-running async task (here, a 3s timer) in a promise that can be
+ * cancelled through an AbortSignal.
+ *
+ *  - If the signal is ALREADY aborted when we start, reject immediately with
+ *    the abort reason (no point starting the work).
+ *  - Otherwise start a 3s timer that resolves with `true` on completion.
+ *  - We also subscribe to the signal's "abort" event: if it fires before the
+ *    timer completes, we clear the pending timeout and reject instead —
+ *    this is what makes the operation cancellable.
+ */
 function cancellablePromise(signal) {
     return new Promise((resolve, reject) => {
         if(signal.aborted) return reject(signal.reason);
-    
+
         const timeoutId = setTimeout(() => {
             return resolve(true);
         }, 3000);
@@ -44,6 +58,8 @@ function cancellablePromise(signal) {
     })
 }
 
+// AbortController produces a `signal` we can pass around and an `.abort()`
+// method that flips that signal to the aborted state.
 const controller = new AbortController();
 const signal = controller.signal;
 
@@ -53,6 +69,8 @@ pr.then((res) => {
     console.log(res);
 }).catch(err => {
     console.log("Err is: ", err);
-}) 
+})
 
+// Called synchronously right after — so the abort fires before the 3s timer,
+// and the promise rejects with "This has been aborted!".
 controller.abort();

--- a/packages/react-testing/src/components/polyfills/abort-controller1.js
+++ b/packages/react-testing/src/components/polyfills/abort-controller1.js
@@ -1,8 +1,21 @@
+// Demonstrates cancelling an in-flight fetch() request using AbortController.
 let data = null;
 
+// A single controller/signal pair shared by every fetchApi call below.
 const controller = new AbortController();
 const signal = controller.signal;
 
+/**
+ * fetchApi(url)
+ * Fires a fetch for `url`, passing the shared `signal` so the request can be
+ * aborted. On the first response it calls controller.abort() — which cancels
+ * any OTHER in-flight request tied to the same signal — then parses the JSON.
+ *
+ * NOTE (bug worth flagging): the inner `data = data` on line below assigns the
+ * parameter to itself; it does not update the outer `data` variable because
+ * the parameter shadows it. Also, once a signal is aborted it stays aborted,
+ * so later fetches with the same signal will reject immediately.
+ */
 function fetchApi(url) {
     fetch(url, { signal })
     .then((res) => {
@@ -18,8 +31,10 @@ function fetchApi(url) {
 const API_1 = "https://jsonplaceholder.typicode.com/todos/1";
 const API_2 = "https://jsonplaceholder.typicode.com/todos/2"
 
+// Kick off the first request immediately...
 fetchApi(API_1);
 
+// ...and a second one shortly after. Whichever resolves first aborts the other.
 setTimeout(() => {
     fetchApi(API_2);
 }, 20)

--- a/packages/react-testing/src/components/polyfills/functions.js
+++ b/packages/react-testing/src/components/polyfills/functions.js
@@ -1,6 +1,18 @@
+/**
+ * Timer — a constructor function that counts up over time.
+ *
+ * - `this.seconds` starts at 3000 and is bumped by 1000 every second via
+ *   setInterval. The arrow callback has no `this` of its own, so `this` still
+ *   refers to the Timer instance (this is the key reason an arrow is used).
+ * - Object.setPrototypeOf attaches a prototype exposing getSeconds(), again as
+ *   an arrow so its `this` stays bound to the instance.
+ *
+ * NOTE: setting the prototype AFTER assigning `this.seconds` works here, but
+ * mutating an object's prototype at runtime is generally discouraged for perf.
+ */
 function Timer() {
     this.seconds = 3000;
-    
+
     setInterval(() => {
         this.seconds += 1000;
     }, 1000);
@@ -14,6 +26,7 @@ function Timer() {
 
 const timer = new Timer();
 
+// Poll the timer every 4s and print the accumulated seconds.
 setInterval(() => {
     if(timer) {
         console.log(timer.getSeconds())

--- a/packages/react-testing/src/components/polyfills/index.html
+++ b/packages/react-testing/src/components/polyfills/index.html
@@ -19,17 +19,26 @@
             left: 0;
         }
 
+        .container {
+            width: 300px;
+            height: 200px;
+            overflow-y: scroll;
+            border: 1px solid black;
+        }
+
+        .content {
+            width: 100%;;
+            height: 2000px;
+        }
+
     </style>
 </head>
 <body>
-
-    <div>One</div>
-
-<div>Three</div>
-<script>
-  document.body.append("Two");
-</script>
-    
-    <!-- <script src="./polyfill-event-loop.js"></script> -->
+    <div class="container" onscroll="handleScroll()">
+        <div class="content">
+        </div>
+    </div>
+    <script src="./polyfill-throttle.js"></script>
+    <!-- <script src="./polyfill-event-loop.js"></> -->
 </body>
 </html>

--- a/packages/react-testing/src/components/polyfills/index.html
+++ b/packages/react-testing/src/components/polyfills/index.html
@@ -38,7 +38,7 @@
         <div class="content">
         </div>
     </div>
-    <script src="./polyfill-throttle.js"></script>
+    <script src="./polyfill-throttle-using-date.js"></script>
     <!-- <script src="./polyfill-event-loop.js"></> -->
 </body>
 </html>

--- a/packages/react-testing/src/components/polyfills/interview-prep.js
+++ b/packages/react-testing/src/components/polyfills/interview-prep.js
@@ -1,0 +1,48 @@
+/**
+ * myRace(promises) — a polyfill of Promise.race().
+ *
+ * Returns a new promise that settles as soon as the FIRST input promise
+ * settles: it resolves with that promise's value, or rejects with its error.
+ *
+ * How it works: we loop over every promise and await each in its own async
+ * callback. The first one to finish calls resolve()/reject(); because a
+ * promise can only settle once, all later settle calls are no-ops.
+ *
+ * NOTE: the `resolved` flag and `finally` block here don't actually gate
+ * anything (they run per-iteration and `return` inside forEach is ignored),
+ * but they're harmless — the real "first wins" behaviour comes from the
+ * one-time settling of the outer promise.
+ */
+const myRace = function (promises) {
+    let resolved = null;
+    return new Promise((resolve, reject) => {
+        promises.forEach(async (promise) => {
+            if(resolved) return resolved;
+            try {
+                const res = await promise;
+                resolve(res);
+            } catch (err) {
+                reject(err);
+            } finally {
+                resolved = this;
+            }
+        });
+    });
+};
+
+// p1 resolves after 3s, p2 after 1s — so the race resolves with 2 (p2 wins).
+const p1 = new Promise((resolve, _) => {
+    setTimeout(() => {
+        resolve(1);
+    }, 3000);
+});
+
+const p2 = new Promise((resolve, _) => {
+    setTimeout(() => {
+        resolve(2);
+    }, 1000);
+});
+
+myRace([p1, p2]).then((res) => {
+    console.log(res);
+});

--- a/packages/react-testing/src/components/polyfills/polyfill-array-flat.js
+++ b/packages/react-testing/src/components/polyfills/polyfill-array-flat.js
@@ -1,5 +1,19 @@
 const unflattened = [1, 2, [3, 4, [5, 6, [7,8]]]];
 
+/**
+ * flattenArray(arr, depth = 100) — a polyfill of Array.prototype.flat().
+ *
+ * Recursively flattens nested arrays up to `depth` levels deep.
+ *
+ * Base cases:
+ *   - an empty array returns []
+ *   - a non-array value is returned as-is (defensive guard)
+ *
+ * Recursive step: for each item, if it's an array AND we still have depth
+ * budget, flatten it one level down (depth - 1) and spread the result into the
+ * accumulator; otherwise push the item unchanged. Decrementing depth is what
+ * stops the recursion at the requested level.
+ */
 function flattenArray(arr, depth = 100) {
     const isArray = Array.isArray(arr);
     const flattened = [];
@@ -19,8 +33,10 @@ function flattenArray(arr, depth = 100) {
     return flattened;
 }
 
+// Expose it on the prototype so it can be called as arr.flattenArray().
 Array.prototype.flattenArray = flattenArray;
 
+// depth = 1 → only one level is flattened: [1, 2, 3, 4, [5, 6, [7, 8]]]
 const flattened = flattenArray(unflattened, 1);
 
 console.log(flattened);

--- a/packages/react-testing/src/components/polyfills/polyfill-bind.js
+++ b/packages/react-testing/src/components/polyfills/polyfill-bind.js
@@ -1,18 +1,34 @@
+/**
+ * Function.prototype.myBind — a (simplified) polyfill of Function.prototype.bind.
+ *
+ * bind() returns a NEW function that, when later called, runs the original
+ * with `this` permanently set to `thisArg` and `args` pre-filled (partial
+ * application). Here we capture the target function as `this` and re-invoke it
+ * via .call(thisArg, ...args) inside the returned wrapper.
+ *
+ * NOTE: this version is incomplete vs. the spec — it doesn't `return` the
+ * result of the call, and it doesn't merge args passed at call time. It's a
+ * teaching stub showing the core idea (return a function that fixes `this`).
+ */
 Function.prototype.myBind = function(thisArg, ...args) {
     return function() {
         this.call(thisArg, ...args);
     }
 };
 
+// A plain function that reads `this.name` — its output depends on how it's called.
 const nameOp = function() {
     console.log(this.name);
 }
 
+// In non-strict mode a bare call sets `this` to the global object; assigning
+// globalThis.name makes `nameOp()` print "Abhishek".
 globalThis.name = "Abhishek";
 
 const anmol = {
     name: "Anmol"
 };
 
+// Called without binding → `this` is the global object → logs "Abhishek".
+// (Try: nameOp.myBind(anmol)() to see binding to `anmol` instead.)
 nameOp();
-

--- a/packages/react-testing/src/components/polyfills/polyfill-call.js
+++ b/packages/react-testing/src/components/polyfills/polyfill-call.js
@@ -1,6 +1,28 @@
-function fn() {
-    console.log(this);
+Function.prototype.myCall = function(thisArg, ...args) {
+    
+    thisArg = thisArg || globalThis;
+    
+    let callerFn = this;
+    thisArg.fn = callerFn;
+
+    thisArg.fn(...args);
+
+    delete thisArg.fn;
 };
 
-// Write this
-fn();
+Function.prototype.myApply = function(thisArg, args = []) {
+    thisArg = thisArg || globalThis;
+
+    thisArg.fn = this;
+    thisArg.fn(...args);
+
+    delete thisArg.fn;
+}
+
+function printName(...args) {
+    console.log(this.name, ...args);
+}
+
+printName.myApply({
+    name: 'preet'
+}, [1, 2, 3]);

--- a/packages/react-testing/src/components/polyfills/polyfill-debounce.js
+++ b/packages/react-testing/src/components/polyfills/polyfill-debounce.js
@@ -1,5 +1,18 @@
+// Grab the search input the debounced handler will listen to.
 const input = document.getElementById("searchIp");
 
+/**
+ * debouncedFn(fn, interval = 3000) — a debounce higher-order function.
+ *
+ * Debouncing delays running `fn` until the user has stopped triggering the
+ * event for `interval` ms. Every call clears the previously scheduled timeout
+ * and schedules a fresh one, so rapid-fire events (e.g. keystrokes) collapse
+ * into a single call after the pause.
+ *
+ * `timeoutId` lives in the closure so it persists across calls of the
+ * returned function. `...args` are forwarded so the original event object
+ * reaches `fn`.
+ */
 function debouncedFn(fn, interval = 3000) {
     let timeoutId = null;
 
@@ -14,11 +27,12 @@ function debouncedFn(fn, interval = 3000) {
 
 let search = "";
 
+// The actual work we want to debounce: reading the input's current value.
 function handleSearch (inp) {
     console.log("Searchin", inp.target.value);
 }
 
+// Wrap handleSearch so it only fires once typing pauses for the interval.
 const debouncedSearch = debouncedFn(handleSearch);
 
 input.addEventListener("input", debouncedSearch)
-

--- a/packages/react-testing/src/components/polyfills/polyfill-event-loop.js
+++ b/packages/react-testing/src/components/polyfills/polyfill-event-loop.js
@@ -1,11 +1,18 @@
+// Demonstrates how the browser's paint pipeline vs. requestAnimationFrame
+// interact — an event-loop timing exercise.
 const box = document.getElementById("box");
 
+// Synchronous style changes: the first (red) is immediately overwritten by the
+// last (blue) within the same task, so the browser never paints red.
 box.style.backgroundColor = "red";
 
-
-
+// requestAnimationFrame runs its callback just BEFORE the next repaint, i.e.
+// after the current synchronous task finishes. So even though this line is
+// written before the "blue" assignment, its "black" runs later.
 requestAnimationFrame(() => {
     box.style.backgroundColor = "black";
 })
 
+// Runs synchronously now → box is blue when the task ends. Then the rAF
+// callback fires before paint and sets it to black, which is what renders.
 box.style.backgroundColor = "blue";

--- a/packages/react-testing/src/components/polyfills/polyfill-filter-1.js
+++ b/packages/react-testing/src/components/polyfills/polyfill-filter-1.js
@@ -1,4 +1,5 @@
 // const arr = [1, 2, 3];
+// Predicate used for the demo: keep only even numbers.
 const filterFn = function(num) {
     return num % 2 == 0;
 };
@@ -8,6 +9,17 @@ const filterFn = function(num) {
 // console.log(filtered);
 
 
+/**
+ * myFilter(callbackFn) — a polyfill of Array.prototype.filter().
+ *
+ * Walks the array by index and builds a new array containing only the elements
+ * for which `callbackFn` returns a truthy value. The original array is not
+ * mutated.
+ *
+ * The Object.hasOwn(this, k) check is what makes it SPARSE-array safe: holes
+ * (missing indices, e.g. the gaps in [1, , 4]) are skipped rather than passed
+ * to the callback — matching native filter's behaviour.
+ */
 const myFilter = function(callbackFn) {
     const newArr = [];
     let k = 0;
@@ -25,6 +37,8 @@ const myFilter = function(callbackFn) {
 
 Array.prototype.myFilter = myFilter;
 
+// Deliberately sparse array (holes at indices 3, 5, 6) to exercise the
+// hole-skipping logic above. Result: [2, 4].
 const arr = [1, 2, 3, , 4, , , 5];
 
 const filtered = arr.myFilter(filterFn);

--- a/packages/react-testing/src/components/polyfills/polyfill-map-final.js
+++ b/packages/react-testing/src/components/polyfills/polyfill-map-final.js
@@ -1,8 +1,21 @@
+/**
+ * mapPolyfill(callbackFn) — a polyfill of Array.prototype.map().
+ *
+ * Returns a NEW array of the same length where each element is the result of
+ * callbackFn(element). Written to be called with any array-like `this`
+ * (see the .call() usage below).
+ *
+ * Key details:
+ *   - `new Array(this.length)` pre-sizes the result so holes are preserved at
+ *     their original indices.
+ *   - Object.hasOwn(this, k) skips holes, so sparse slots stay empty rather
+ *     than being mapped — matching native map.
+ */
 const mapPolyfill = function(callbackFn) {
     const finalArr = new Array(this.length);
     let k = 0;
     while( k < this.length) {
-        if(Object.hasOwn(this, k)){ 
+        if(Object.hasOwn(this, k)){
             const value = callbackFn(this[k]);
             finalArr[k] = value;
         }
@@ -13,10 +26,13 @@ const mapPolyfill = function(callbackFn) {
 
 Array.prototype.myMap = mapPolyfill;
 
+// An array-LIKE object (has length + indexed keys but isn't a real array).
+// Only indices 0 and 1 exist; the other 18 slots are holes.
 const arr = { length: 20, 0: 1, 1: 3};
 const squared = function(num) {
     return num * num;
 };
 
+// Borrow myMap via .call so `this` inside it is the array-like object.
 const squaredArray = Array.prototype.myMap.call(arr, squared);
 console.log(squaredArray);

--- a/packages/react-testing/src/components/polyfills/polyfill-map.js
+++ b/packages/react-testing/src/components/polyfills/polyfill-map.js
@@ -6,6 +6,15 @@
 
 // Method1
 
+/**
+ * customMap(cb) — the simplest possible Array.prototype.map() polyfill.
+ *
+ * Iterates with the built-in forEach, applies `cb` to each element, and
+ * collects the results into a new array (the original is untouched).
+ *
+ * Unlike the index-based versions in the sibling files, this relies on
+ * forEach, so it naturally skips holes but does not preserve their positions.
+ */
 const customMap = function(cb){
     const newArr = [];
     this.forEach((item) => {

--- a/packages/react-testing/src/components/polyfills/polyfill-map1.js
+++ b/packages/react-testing/src/components/polyfills/polyfill-map1.js
@@ -1,10 +1,23 @@
 const x = [1, 2, 3, 4];
 
+/**
+ * transformFn(item, index, arr) — sample callback squaring each item.
+ * It logs `this` to show what the map polyfill binds the callback's `this` to
+ * (here `null` is passed as thisArg below).
+ */
 const transformFn = (item, index, arr) => {
     console.log(this);
     return item * item;
 }
 
+/**
+ * myMap(arr, callbackFn, thisArg) — a standalone (non-prototype) map polyfill.
+ *
+ * Takes the array explicitly as the first argument rather than via `this`.
+ * For every index it invokes callbackFn using .call(thisArg, ...) so the
+ * callback receives the standard (element, index, array) trio AND the caller
+ * can control the callback's `this` binding through `thisArg`.
+ */
 function myMap(arr, callbackFn, thisArg) {
     let finalArr = [];
 
@@ -17,6 +30,8 @@ function myMap(arr, callbackFn, thisArg) {
     return finalArr;
 }
 
+// Array-like object (length + numeric keys) to show myMap isn't limited to
+// real arrays.
 const arrSupreme = {
     length: 2,
     0: 10,
@@ -25,4 +40,5 @@ const arrSupreme = {
 
 const ans = myMap(arrSupreme, transformFn, null);
 
+// Unrelated demo of Array.from with a mapper: builds [0,1,2,...,9].
 console.log(Array.from({length: 10}, (_,i) => i ));

--- a/packages/react-testing/src/components/polyfills/polyfill-new.js
+++ b/packages/react-testing/src/components/polyfills/polyfill-new.js
@@ -1,3 +1,4 @@
+// A sample constructor + prototype method to exercise the `new` polyfill.
 function Car(name) {
     this.name = name;
 }
@@ -6,6 +7,23 @@ Car.prototype.driving = function() {
     console.log("Driving", this.name);
 };
 
+/**
+ * myNew(ConstructorFn, ...args) — a polyfill of the `new` operator.
+ *
+ * The `new` operator does four things, which this function reproduces:
+ *   1. Create a fresh empty object.
+ *   2. Link that object's prototype to the constructor's prototype (so
+ *      instances inherit methods like Car.prototype.driving). Here we build a
+ *      `newProtoType` that carries a `constructor` back-reference and copies
+ *      the constructor's own prototype keys, then setPrototypeOf links it.
+ *   3. Run the constructor with `this` bound to the new object (via .call),
+ *      passing the forwarded args — this is what sets instance fields.
+ *   4. Return the new object.
+ *
+ * NOTE: Object.keys only copies ENUMERABLE OWN keys, so inherited/non-enumerable
+ * prototype members wouldn't be picked up. Real `new` just links the prototype
+ * directly (Object.setPrototypeOf(obj, ConstructorFn.prototype)) instead of copying.
+ */
 function myNew(ConstructorFn, ...args) {
     const newlyCreatedObject = {};
 

--- a/packages/react-testing/src/components/polyfills/polyfill-object-create.js
+++ b/packages/react-testing/src/components/polyfills/polyfill-object-create.js
@@ -1,3 +1,4 @@
+// The object we want new objects to inherit from (the prototype).
 const animal = {
     name: "Default animal",
     type: "Default animal"
@@ -5,6 +6,21 @@ const animal = {
 
 // const cheetah = Object.create(animal);
 
+/**
+ * myCreate(object, properties) — a polyfill of Object.create().
+ *
+ * Object.create builds a new object whose prototype is `object` and whose own
+ * properties come from a property-descriptor map. This version:
+ *   1. Creates an empty object.
+ *   2. Applies the descriptor map via Object.defineProperties (each value is a
+ *      descriptor like { value, writable, enumerable, configurable }).
+ *   3. Links the prototype with setPrototypeOf so lookups fall through to
+ *      `object` (e.g. cheetah.name resolves to "Default animal").
+ *
+ * NOTE: native Object.create sets the prototype at creation time; doing
+ * defineProperties first then setPrototypeOf yields the same observable result
+ * here.
+ */
 function myCreate(object, properties) {
     const newObject = {};
     Object.defineProperties(newObject, properties);
@@ -12,6 +28,7 @@ function myCreate(object, properties) {
     return newObject;
 }
 
+// cheetah gets an own property "newValue" and inherits name/type from animal.
 const cheetah = myCreate(animal, {
     "newValue": {
         value: "Abcd"

--- a/packages/react-testing/src/components/polyfills/polyfill-reduce.js
+++ b/packages/react-testing/src/components/polyfills/polyfill-reduce.js
@@ -1,9 +1,29 @@
 const arr = [1, 2, 3, 4];
 
+// Reducer callback: sum the accumulator and the current element.
 const reduceArr = (acc, curr) => {
     return acc + curr;
 };
 
+/**
+ * myReduce(callbackFn, init) — a polyfill of Array.prototype.reduce().
+ *
+ * Folds the array into a single value by repeatedly calling
+ * callbackFn(accumulator, currentElement).
+ *
+ * Initial-value handling (matching native reduce):
+ *   - If `init` is provided, start from it and begin at index 0.
+ *   - If `init` is omitted, use the first element as the seed and start at
+ *     index 1 (so the first element isn't fed through the callback twice).
+ *   - Reducing an empty array with no init throws — reproduced here.
+ *
+ * Object.hasOwn(this, k) skips holes in sparse arrays.
+ *
+ * CAVEAT: the check uses `init` truthiness (`init ? ...`), so a falsy seed such
+ * as 0 or "" is treated as "no init". Native reduce checks argument presence
+ * instead. It happens to work in this demo because the array's first element
+ * is 1.
+ */
 Array.prototype.myReduce = function(callbackFn, init) {
     if(this.length === 0) throw new Error("Can not call on empty array! ");
     const initialValue = init || this[0];

--- a/packages/react-testing/src/components/polyfills/polyfill-setInterval.js
+++ b/packages/react-testing/src/components/polyfills/polyfill-setInterval.js
@@ -1,3 +1,16 @@
+/**
+ * mySetInterval(callbackFn, interval, ...args) — a polyfill of setInterval
+ * built on top of requestIdleCallback instead of the native timer.
+ *
+ * It assigns each interval a monotonically increasing id (stored on
+ * window.myIntervalId), records a descriptor { id, exec, timeToRun, interval,
+ * args }, registers it, and kicks off the polling loop via runCallback.
+ *
+ * NOTE: there are typos in the registry bookkeeping — it writes to
+ * `window.myIntevals` (misspelt) on first use but reads `window.myIntervals`
+ * elsewhere, so registration/clearing are inconsistent. Left as-is; flagged
+ * for awareness.
+ */
 const mySetInterval = function(callbackFn, interval, ...args) {
     let intervalId = window.myIntervalId;
     if(!intervalId) {
@@ -25,6 +38,17 @@ const mySetInterval = function(callbackFn, interval, ...args) {
 
 // 1000ms
 // 10:00 -> 10:01
+/**
+ * runCallback(data) — the recurring driver for one interval.
+ *
+ * On each tick it checks whether the due time (timeToRun) has passed; if so it
+ * runs the callback and schedules the next due time one `interval` later. It
+ * then re-queues itself with requestIdleCallback, which runs the check during
+ * the browser's idle periods — approximating a repeating timer.
+ *
+ * NOTE: because timeToRun is a local copy, the recomputed value must be passed
+ * forward on each recursion (as done here) for the interval to advance.
+ */
 function runCallback(data) {
     let { exec, interval, args, timeToRun } = data;
     if(Date.now() >= timeToRun) {
@@ -41,6 +65,10 @@ function runCallback(data) {
     })
 }
 
+/**
+ * myClearInterval(id) — cancels an interval by removing its descriptor from
+ * the registry so runCallback stops finding/executing it.
+ */
 const myClearInterval = (id) => {
     window.myIntervals = window.myIntervals.filter((interval) => interval.id !== id);
 };

--- a/packages/react-testing/src/components/polyfills/polyfill-setTimeout.js
+++ b/packages/react-testing/src/components/polyfills/polyfill-setTimeout.js
@@ -1,3 +1,11 @@
+/**
+ * mySetTimeout(callbackFn, interval, ...args) — a polyfill of setTimeout built
+ * on requestIdleCallback rather than the native timer.
+ *
+ * Assigns an incrementing id (window.timeoutId), stores a descriptor
+ * { id, exec, args, interval, timeToRun } in the window.timeouts registry,
+ * starts the polling loop, and returns the id so it can be cleared later.
+ */
 const mySetTimeout = function(callbackFn, interval, ...args) {
     let timeoutId = window.timeoutId;
     if(!timeoutId) {
@@ -24,12 +32,24 @@ const mySetTimeout = function(callbackFn, interval, ...args) {
     return timeoutId;
 }
 
+/**
+ * clearMyTimeout(timeoutId) — a polyfill of clearTimeout. Removes the matching
+ * descriptor from the registry so its callback never fires.
+ */
 const clearMyTimeout = function(timeoutId) {
     const newTimeouts = window.timeouts.filter((item) => item?.id !== timeoutId);
 
     window.timeouts = newTimeouts;
 }
 
+/**
+ * runCallbacks() — the polling driver.
+ *
+ * Scans every pending timeout: if its due time has passed, it runs the
+ * callback once and removes it (one-shot, unlike setInterval). Otherwise it
+ * re-schedules the scan via requestIdleCallback so the browser re-checks
+ * during idle time until each timeout comes due.
+ */
 const runCallbacks = function() {
     const timeouts = window.timeouts;
 
@@ -44,6 +64,7 @@ const runCallbacks = function() {
     })
 }
 
+// Schedule a one-shot callback ~1s out and inspect the registry before/after.
 const id = mySetTimeout(function(){
     console.log("Hi");
 }, 1000);

--- a/packages/react-testing/src/components/polyfills/polyfill-slice.js
+++ b/packages/react-testing/src/components/polyfills/polyfill-slice.js
@@ -6,6 +6,25 @@ const arr = [1, 2, 3, 4];
 
 // Index not available: sparse array
 
+/**
+ * mySlice(startIndex, endIndex) — a polyfill of Array.prototype.slice().
+ *
+ * Returns a shallow copy of a portion of the array from `start` up to (but not
+ * including) `end`, without mutating the original.
+ *
+ * Argument handling:
+ *   - No args → returns the whole array.
+ *   - Missing end → defaults to the array length; end past the length is
+ *     clamped to the length.
+ *   - Negative start/end → treated as offsets from the end (the while loops
+ *     add the length until the index becomes non-negative).
+ *
+ * Object.hasOwn(this, k) skips holes so sparse arrays stay sparse-safe.
+ *
+ * CAVEAT: the guard `if(!startIndex && !endIndex)` treats a real 0 argument as
+ * "not provided", and `start = startIndex % arrLength` behaves oddly for
+ * positive starts. It's a teaching implementation, not spec-exact.
+ */
 Array.prototype.mySlice = function(startIndex, endIndex) {
     const arr = Array.from(this);
     if(!Array.isArray(arr)) throw new Error("Not an array!");
@@ -44,5 +63,5 @@ Array.prototype.mySlice = function(startIndex, endIndex) {
     return newArray;
 };
 
+// end = -1 → normalised to length-1 (3), so this copies indices 0..2 → [1,2,3].
 const sliced = arr.mySlice(0, -1);
-

--- a/packages/react-testing/src/components/polyfills/polyfill-throttle-using-date.js
+++ b/packages/react-testing/src/components/polyfills/polyfill-throttle-using-date.js
@@ -1,0 +1,39 @@
+const throttledFn = function(fn, delay, options = {}) {
+    let lastCalled = 0;
+    let timeoutId = null;
+
+    const { leading = false, trailing = true } = options;
+    return function(...args) {
+
+        if(lastCalled == 0 && !leading) lastCalled = Date.now();
+        let diff = Date.now() - lastCalled;
+        // leading call
+        if(diff >= delay && leading) {
+            // call the function
+            console.log("Leading call");
+            fn(...args);
+
+            // set lastCalled to now
+            lastCalled = Date.now();
+        } 
+        // Trailing
+        else if(trailing && !timeoutId) {
+            timeoutId = setTimeout(() => {
+                console.log("Trailing call");
+                fn(...args);
+                clearTimeout(timeoutId);
+                timeoutId = null;
+            }, delay);
+        }
+    }
+}
+
+const fn = () => {
+    console.log("hello");
+}
+
+const throttled = throttledFn(fn, 2000);
+
+const handleScroll = () => {
+    throttled();
+}

--- a/packages/react-testing/src/components/polyfills/polyfill-throttle.js
+++ b/packages/react-testing/src/components/polyfills/polyfill-throttle.js
@@ -1,0 +1,22 @@
+const throttledFn = function(fn, interval) {
+    let timeoutId = null;
+    return function(...args) {
+        if(timeoutId) return;
+
+        timeoutId = setTimeout(() => {
+            fn(...args);
+            clearTimeout(timeoutId);
+            timeoutId = null;
+        }, interval);
+    }
+}
+
+const fn = () => {
+    console.log("hello");
+}
+
+const throttled = throttledFn(fn, 1000);
+
+const handleScroll = () => {
+    throttled();
+}

--- a/packages/react-testing/src/components/polyfills/promise-all.js
+++ b/packages/react-testing/src/components/polyfills/promise-all.js
@@ -1,0 +1,41 @@
+const myAll = function(promises) {
+    let allPromiseValues = Array.from({ length: promises.length }, () => undefined);
+    const isAnyPromiseUnresolved = () => {
+        return allPromiseValues.some((val) => val === undefined);
+    }
+    return new Promise((resolve, reject) => {
+        // resolve the promise when all promises are resolved
+            promises.forEach(async (promise, index) => {
+                try {
+                    const res = await promise;
+                    if(res) allPromiseValues[index] = res;
+                    if(!isAnyPromiseUnresolved()) {
+                        resolve(allPromiseValues);
+                    }
+                } catch(err) {
+                    reject(err);
+                }
+            })
+        // in case any promise rejects, reject the promise
+    })
+};
+
+const p1 = new Promise((resolve, reject) =>{
+    setTimeout(() => {
+        resolve(3);
+    }, 1000)
+})
+
+const p2 = new Promise((resolve, reject) =>{
+    setTimeout(() => {
+        reject(5);
+    }, 3000)
+})
+
+const p3 = myAll([p1, p2]);
+
+p3.then((res) => {
+    console.log(res);
+}).catch((err) => {
+    console.log(err);
+})

--- a/packages/react-testing/src/components/polyfills/promises-polyfill.js
+++ b/packages/react-testing/src/components/polyfills/promises-polyfill.js
@@ -10,11 +10,33 @@
 //     console.log(res);
 // });
 
+/**
+ * MyPromise — a from-scratch polyfill of the native Promise, built to
+ * understand how promises work under the hood (state machine + callback
+ * queues + microtask scheduling).
+ *
+ * A promise is essentially a state machine with three states:
+ *   "pending"  → the initial state, no value settled yet
+ *   "resolved" → settled successfully with a value
+ *   "rejected" → settled with an error/failure value
+ * Once it leaves "pending" it can never change again (it is immutable).
+ */
 class MyPromise {
-    #value = "";
-    #state = "pending";
-    #thenCbs = [];
-    #catchcbs = [];
+    // Private fields (# prefix) — inaccessible from outside the class.
+    #value = "";          // the settled value (success value or failure reason)
+    #state = "pending";   // current state of the state machine
+    #thenCbs = [];        // queue of success callbacks registered via .then()
+    #catchcbs = [];       // queue of failure callbacks registered via .then()/.catch()
+
+    /**
+     * constructor(callback)
+     * Receives the "executor" function that the caller passes in, e.g.
+     *   new MyPromise((resolve, reject) => { ... })
+     * It is invoked immediately (synchronously) with our internal
+     * #onSuccess / #onFail handlers wired in as `resolve` / `reject`.
+     * Any error thrown synchronously inside the executor rejects the promise,
+     * mirroring the native Promise behaviour.
+     */
     constructor(callback) {
         try {
             callback(this.#onSuccess, this.#onFail);
@@ -23,6 +45,14 @@ class MyPromise {
         }
     }
 
+    /**
+     * #runCallbacks()
+     * Drains the appropriate callback queue based on the current state.
+     * Wrapped in queueMicrotask() so callbacks always run asynchronously on
+     * the microtask queue (never synchronously) — this matches the native
+     * spec guarantee that .then handlers run after the current call stack
+     * clears. Each queue is emptied after firing so callbacks run only once.
+     */
     #runCallbacks = () => {
         queueMicrotask(() => {
             if (this.#state === "resolved") {
@@ -41,6 +71,13 @@ class MyPromise {
         });
     };
 
+    /**
+     * #onSuccess(successVal)  — the internal `resolve` function.
+     * Transitions the promise from "pending" → "resolved", stores the value,
+     * and triggers any queued success callbacks.
+     * The guard `if (this.#state !== "pending") return;` enforces immutability:
+     * a promise can only settle once, so a second call is ignored.
+     */
     #onSuccess = (successVal) => {
         if (this.#state !== "pending") return;
 
@@ -50,6 +87,12 @@ class MyPromise {
         this.#runCallbacks();
     };
 
+    /**
+     * #onFail(failVal)  — the internal `reject` function.
+     * Transitions the promise from "pending" → "rejected", stores the failure
+     * reason, and triggers any queued catch callbacks.
+     * Same one-time settle guard as #onSuccess.
+     */
     #onFail = (failVal) => {
         if (this.#state !== "pending") return;
 
@@ -59,6 +102,26 @@ class MyPromise {
         this.#runCallbacks();
     };
 
+
+    /**
+     * then(thenCb, errCb)
+     * Registers a success handler (and optional error handler) and returns a
+     * NEW MyPromise so calls can be chained (.then().then()...).
+     *
+     * The returned promise resolves with whatever `thenCb` returns, which is
+     * what lets each link in a chain receive the previous link's return value.
+     *
+     * How it works:
+     *  - We push a wrapper onto #thenCbs. When this promise resolves, the
+     *    wrapper runs thenCb(value) and resolves the new promise with its
+     *    result. If no thenCb was given, the value is passed straight through.
+     *  - If an errCb was provided, a matching wrapper is queued on #catchcbs.
+     *  - #runCallbacks() is called in case this promise has ALREADY settled
+     *    before .then() was attached, so the handler still fires.
+     *
+     * Note: this is a simplified model — it does not yet flatten (unwrap)
+     * returned promises the way the native spec does.
+     */
     then = (thenCb, errCb) => {
         return new MyPromise((resolve,_) => {
 
@@ -72,13 +135,13 @@ class MyPromise {
             });
 
             if (errCb) {
-                this.#catchcbs.push((resolvedValue) => {
+                this.#catchcbs.push((rejectedValue) => {
                     return new MyPromise((resolve, reject) => {
                         if(!errCb) {
-                            reject(resolvedValue);
+                            reject(rejectedValue);
                             return;
                         } else {
-                            const rejectedVal = errCb(resolvedValue);
+                            const rejectedVal = errCb(rejectedValue);
                             return reject(rejectedVal);
                         }
                     })
@@ -89,16 +152,31 @@ class MyPromise {
         });
     };
 
+    /**
+     * catch(catchCb)
+     * Sugar for handling only the rejection case. Delegates to then() with no
+     * success handler and catchCb as the error handler — exactly how the
+     * native Promise.prototype.catch is defined.
+     */
     catch = (catchCb) => {
         this.then(undefined, catchCb);
     };
 
+    /**
+     * MyPromise.resolve(value)  — static helper.
+     * Returns a promise that is already resolved with the given value.
+     * Handy for wrapping a plain value in a promise.
+     */
     static resolve = (resolvedValue) => {
         return new MyPromise((resolve, reject) => {
             resolve(resolvedValue);
         });
     };
 
+    /**
+     * MyPromise.reject(reason)  — static helper.
+     * Returns a promise that is already rejected with the given reason.
+     */
     static reject = (rejectedValue) => {
         return new MyPromise((resolve, reject) => {
             reject(rejectedValue);
@@ -106,6 +184,10 @@ class MyPromise {
     };
 }
 
+// --- Demo / manual test ---------------------------------------------------
+// NOTE: fetch() returns a NATIVE promise here, so this snippet exercises the
+// built-in chaining rather than MyPromise. To test MyPromise instead, use the
+// commented example at the top of the file (new MyPromise(...).then(...)).
 const myPromise = fetch('https://dummyjson.com/todos');
 
 myPromise

--- a/packages/react-testing/src/components/polyfills/test.js
+++ b/packages/react-testing/src/components/polyfills/test.js
@@ -1,3 +1,10 @@
+// Quick sanity check of native Promise chaining (baseline for the MyPromise
+// polyfill in promises-polyfill.js).
+//
+// The promise resolves synchronously with 3. The first .then logs "Res1 3" and
+// returns 1; because .then returns a new promise resolved with that return
+// value, the second .then receives 1 and logs "res2 1". Both callbacks run as
+// microtasks, after the surrounding synchronous code.
 const p = new Promise((resolve, reject) => {
     resolve(3);
 })

--- a/packages/react-testing/src/components/polyfills/worker.js
+++ b/packages/react-testing/src/components/polyfills/worker.js
@@ -1,3 +1,13 @@
+// Web Worker script — runs on a background thread, separate from the main UI
+// thread. `self` is the worker's global scope.
+//
+// onmessage fires whenever the main thread calls worker.postMessage(...).
+// Here we do a deliberately heavy CPU loop (17^8 ≈ 6.9 billion iterations) to
+// simulate expensive work. Running it in the worker keeps the main thread — and
+// therefore the page's UI — responsive during the computation.
+//
+// When done, postMessage(k) sends the result back to the main thread's
+// worker.onmessage handler (see workers-practical.js).
 self.onmessage = (message) => {
 
     let k = 0 ;

--- a/packages/react-testing/src/components/polyfills/workers-practical.js
+++ b/packages/react-testing/src/components/polyfills/workers-practical.js
@@ -1,20 +1,38 @@
+// Main-thread side of the Web Worker demo. Pairs with worker.js.
+// Spawns the background worker that will run the heavy computation.
 const worker = new Worker("worker.js");
 
+// Two buttons: one triggers the expensive computation, the other toggles a
+// colour class. The point of the demo: even while the worker crunches numbers,
+// the colour-toggle button stays responsive because the work is off the main
+// thread.
 const computeSumBtn = document.getElementById("computeSum");
 const toggleButtonColorChange = document.getElementById("changeColor");
 
 toggleButtonColorChange.addEventListener("click", handleColorChange);
 computeSumBtn.addEventListener("click", handleComputeSum);
 
+/**
+ * handleColorChange() — toggles a CSS class on <body>. Purely a UI action used
+ * to prove the main thread isn't blocked while the worker runs.
+ */
 function handleColorChange() {
     const body = document.body;
     body.classList.toggle("green");
 }
 
+/**
+ * handleComputeSum() — hands the heavy work off to the worker by posting it a
+ * message. Returns immediately; the result arrives asynchronously below.
+ */
 function handleComputeSum() {
     worker.postMessage("Hello Worker!!");
 }
 
+/**
+ * worker.onmessage — receives the computed result from worker.js and renders
+ * it into a new <div> appended to the page.
+ */
 worker.onmessage = (message) => {
     let div = document.createElement("div");
     div.innerText = `Computed ${message.data}`;

--- a/packages/react-testing/src/components/striver/arrays/kadane.js
+++ b/packages/react-testing/src/components/striver/arrays/kadane.js
@@ -1,0 +1,32 @@
+const arr = [-2, -3, 4, -1, -2, 1, 5, -3];
+// Get max sum of subarray inside this array
+
+
+const getMaxSum = (arr) => {
+    // maintain vars sum and maxSum,
+    // is sum < 0 reset it
+    // else keep it and keep comparing it with maxSum
+
+    const n = arr.length;
+    let maxi = 0;
+    let sum = 0;
+
+    for(let i = 0; i < n; i++) {
+        sum += arr[i];
+
+        // compare sum to maxi
+        if(sum > maxi) {
+            maxi = sum;
+        }
+
+        // if sum < 0, reset it, else continue
+        if(sum < 0) {
+            sum = 0;
+        }
+    }
+
+    return maxi;
+};
+
+const ans = getMaxSum(arr);
+console.log(ans);

--- a/packages/react-testing/src/components/striver/recap/rec/mergeSort.js
+++ b/packages/react-testing/src/components/striver/recap/rec/mergeSort.js
@@ -1,0 +1,56 @@
+const arr = [2, 1, 3, 4, -1];
+
+const mergeSort = (arr) => {
+    const n = arr.length;
+
+    function merge(arr, low, mid, high) {
+        let l = low;
+        let r = mid+1;
+
+        const newArr = [];
+        while(l<=mid && r<=high) {
+            if(arr[l] <= arr[r]) {
+                newArr.push(arr[l]);
+                l++;
+            }
+            else {
+                newArr.push(arr[r]);
+                r++;
+            }
+        }
+
+        while(l <= mid) {
+            newArr.push(arr[l]);
+            l++;
+        }
+
+        while(r <= high) {
+            newArr.push(arr[r]);
+            r++;
+        }
+
+        // replace low->high in original
+ 
+        for(let k = low; k<=high; k++) {
+            arr[k] = newArr[k-low];
+        }
+    }
+
+    function ms(arr, low, high) {
+
+        if(low >= high) return;;
+
+        const mid = Math.floor((low + high) / 2);
+        ms(arr, low, mid);
+        ms(arr, mid+1, high);
+        merge(arr, low, mid, high);
+    }
+
+    ms(arr, 0, n-1);
+
+};
+
+
+mergeSort(arr);
+
+console.log(arr);

--- a/packages/react-testing/src/components/striver/recap/rec/permutations-using-swapping.js
+++ b/packages/react-testing/src/components/striver/recap/rec/permutations-using-swapping.js
@@ -1,0 +1,31 @@
+const arr = [1, 2, 3];
+
+const generatePermutations = (arr) => {
+    const n = arr.length;
+
+    function getPermutations(index, temp) {
+        if(index === n){
+            console.log(temp);
+            return;
+        }
+
+        // for each index from index->n swap one by one
+
+        for(let i=index; i<n; i++) {
+            let currArray = [...temp];
+            // swap index with i
+
+            let tempVar = currArray[index];
+            currArray[index] = currArray[i];
+            currArray[i] = tempVar;
+
+            // recursively call for index+1
+
+            getPermutations(index + 1, currArray);
+        }
+    }
+
+    getPermutations(0, arr);
+};
+
+generatePermutations(arr);

--- a/packages/react-testing/src/components/striver/recap/rec/printPermutations.js
+++ b/packages/react-testing/src/components/striver/recap/rec/printPermutations.js
@@ -1,0 +1,33 @@
+const arr = [1, 2, 3, 1];
+
+const printPermutations = (arr) => {
+    const n = arr.length;
+    const freqMap = new Map();
+    arr.forEach((item) => {
+        freqMap.set(item, (freqMap.get(item) || 0) + 1);
+    });
+
+    function getPermutations(incomingMap, temp) {
+        if(temp.length === n) {
+            console.log(temp);
+            return;
+        }
+
+        // Iterate over incoming map entries (don't modify during iteration)
+        for(let [key, value] of incomingMap) {
+            if(value === 0) continue;
+
+            // Create a new map for this branch
+            const newMap = new Map(incomingMap);
+            newMap.set(key, value - 1);
+
+            temp.push(key);
+            getPermutations(newMap, temp);
+            temp.pop();
+        }
+    }
+
+    getPermutations(freqMap, []);
+}
+
+printPermutations(arr);

--- a/packages/react-testing/src/components/striver/recap/rec/printSubsequenceWithSum.js
+++ b/packages/react-testing/src/components/striver/recap/rec/printSubsequenceWithSum.js
@@ -1,0 +1,34 @@
+const arr = [1, 2, 3, 4, 5, 6];
+const sum = 7;
+
+const getAllSubsequences = (arr, sum) => {
+
+    const n = arr.length;
+    function printSub(index, temp) {
+        // base case
+        if(index === n) {
+            // check for sum
+            let tempSum = temp.reduce((acc, curr) => {
+                return acc + curr;
+            }, 0);
+            if(tempSum === sum) {
+                // print
+                console.log(temp);
+            }
+            return;
+            // else return
+        }
+        // take
+        temp.push(arr[index]);
+        printSub(index+1, temp);
+
+        // not take
+        temp.pop();
+        printSub(index+1, temp);
+        return;
+    }
+
+    printSub(0, []);
+}
+
+getAllSubsequences(arr, sum);

--- a/packages/react-testing/src/components/striver/recap/rec/printUniqueSubsequencesWithSum.js
+++ b/packages/react-testing/src/components/striver/recap/rec/printUniqueSubsequencesWithSum.js
@@ -1,0 +1,33 @@
+const arr = [1, 1, 1, 2, 2];
+const sum = 4;
+
+const getUniqueSubsequences = (arr, sum) => {
+
+    const n = arr.length;
+    function printSubsequences(index, currSum, temp) {
+        // base case
+        if(currSum <= 0 || index === n) {
+            if(currSum === 0) {
+                console.log(temp);
+            }
+            return;
+        }
+
+        // call all index -> n arr indices
+        let prev = null;
+        for(let i=index; i<n; i++) {
+            const isPrevSame = prev === arr[i];
+            
+            if(isPrevSame) continue;
+
+            prev = arr[i];
+            temp.push(arr[i]);
+            printSubsequences(i+1, currSum - arr[i], temp);
+            temp.pop();
+        }
+    }
+
+    printSubsequences(0, sum, []);
+}
+
+getUniqueSubsequences(arr, sum);

--- a/packages/react-testing/src/components/striver/recap/rec/printUniqueSubsets.js
+++ b/packages/react-testing/src/components/striver/recap/rec/printUniqueSubsets.js
@@ -1,0 +1,47 @@
+const arr = [1,1,2 ];
+
+const getUniqueSubsets = (arr) => {
+
+    const n = arr.length;
+    // take not take approach to gen subsets
+    const subsets = (index, temp) => {
+        if(index === n) {
+            console.log(temp);
+            return;
+        }
+
+        // take arr[index]
+        temp.push(arr[index]);
+        subsets(index+1, temp);
+
+        // not take arr[index]
+        temp.pop();
+        subsets(index+1, temp);
+    }
+
+    const uniqueSubsets = (index, temp) => {
+        // base
+        if(index === n) {
+            console.log(temp);
+            return;
+        }
+        console.log(temp);
+        // generate all cases from index -> n
+        // check if new case is not same as prev
+        // pop while returning;
+
+        let prev = null;
+        for(let i = index; i<n; i++ ){
+            if(prev === arr[i]) continue;
+
+            prev = arr[i];
+            temp.push(arr[i]);
+            uniqueSubsets(i+1, temp);
+            temp.pop();
+        }
+    }
+
+    uniqueSubsets(0, []);
+};
+
+getUniqueSubsets(arr);

--- a/packages/react-testing/src/components/striver/recap/rec/subsequencesOfString.js
+++ b/packages/react-testing/src/components/striver/recap/rec/subsequencesOfString.js
@@ -1,0 +1,26 @@
+// using take and not take approach
+
+const getStringSubsequences = (str) => {
+    const n = str.length;
+
+    function printSubsequences(index, tempStr) {
+        if(index === n) {
+            console.log(tempStr);
+            return;
+        }
+
+        // Take index in tempStr
+        tempStr+=str[index];
+        printSubsequences(index+1, tempStr);
+
+
+        const sliced = tempStr.slice(0, -1);
+        printSubsequences(index+1, sliced);
+        // pop and do not take
+    }
+
+    printSubsequences(0, "");
+};
+
+const str = "abcd";
+getStringSubsequences(str);

--- a/packages/react-testing/src/components/striver/recap/slidingWindows/constant.js
+++ b/packages/react-testing/src/components/striver/recap/slidingWindows/constant.js
@@ -1,0 +1,37 @@
+const arr = [11, -2, 10, 14];
+
+const windowSize = 3;
+
+const getMaxSum = (arr, windowSize) => {
+    const n = arr.length;
+
+    let l = 0;
+    let r = windowSize-1;
+
+    let maxSum = -100;
+    let sum = 0;
+    
+    for(let i=l; i<=r; i++) {
+        sum+= arr[i];
+    };
+    if(sum > maxSum) maxSum = sum;
+
+    while(r < n) {
+       
+        // remove arr[l-1] and add arr[r];
+        sum-=arr[l];
+        l++;
+        r++;
+        sum+=arr[r];
+        
+        if(sum > maxSum) maxSum = sum;
+        
+        
+    }
+
+    return maxSum;
+
+}
+
+const ans = getMaxSum(arr, windowSize);
+console.log(ans);

--- a/packages/react-testing/src/components/striver/recap/slidingWindows/fruitsInBasket.js
+++ b/packages/react-testing/src/components/striver/recap/slidingWindows/fruitsInBasket.js
@@ -1,0 +1,45 @@
+const fruits = [3, 3, 3, 1, 1, 1, 2, 3, 3, 4];
+
+const maxFruitsOfSameType = (fruits) => {
+    const fruitsMap = {};
+
+    const n = fruits.length;
+    let maxFruits = 0;
+
+    let l = 0;
+    let r = 0;
+
+    const hasMap2Entries = (map) => {
+        return Object.keys(map).length <= 2;
+    }
+
+    const collectedFruits = (map) => {
+        return Object.values(map).reduce((acc, curr) => acc+curr, 0);
+    };
+
+    while(r < n) {
+        // pick fruits[r] and populate map
+        fruitsMap[fruits[r]] = (fruitsMap?.[fruits[r]] || 0) + 1;
+        // remove fruites[l] till map contain 2 entries
+
+        while(!hasMap2Entries(fruitsMap)) {
+            fruitsMap[fruits[l]] = fruitsMap[fruits[l]] - 1;
+            if(fruitsMap[fruits[l]] === 0) {
+                delete fruitsMap[fruits[l]];
+            }
+            l++;
+        }
+        // check for max fruits
+
+        const collected = collectedFruits(fruitsMap);
+        maxFruits = Math.max(collected, maxFruits);
+
+        // r++;
+        r++;
+    }
+
+    return maxFruits;
+}
+
+const ans = maxFruitsOfSameType(fruits);
+console.log(ans);

--- a/packages/react-testing/src/components/striver/recap/slidingWindows/maxLenWithSumK.js
+++ b/packages/react-testing/src/components/striver/recap/slidingWindows/maxLenWithSumK.js
@@ -1,0 +1,29 @@
+const arr = [2, 5, 1, 7,1, 10];
+const k = 14;
+
+const findMaxLen = (arr, k) => {
+    let l = 0;
+    let r = 0;
+    const n = arr.length;
+    let sum = 0;
+    let maxLen = -1;
+
+    while(r < n) {
+        sum+= arr[r];
+
+        while(sum > k) {
+            sum-=arr[l];
+            l++;
+        }
+
+        let len = (r-l+1);
+
+        maxLen = Math.max(len, maxLen);
+        r++;
+    }
+
+    return maxLen;
+}
+
+const ans = findMaxLen(arr, k);
+console.log(ans);

--- a/packages/react-testing/src/components/striver/stack-queue/README.md
+++ b/packages/react-testing/src/components/striver/stack-queue/README.md
@@ -1,0 +1,207 @@
+# Stack & Queue — Revision Notes
+
+Quick-revision guide for all problems covered in this folder. Each entry has the **problem**, the **core idea**, and the **implementation strategy** so you can recall the approach without re-reading the code.
+
+---
+
+## Contents
+
+**Data Structures (building blocks)**
+1. [Stack using Array](#1-stack-using-array) — `stack-arr.js`
+2. [Stack using Linked List](#2-stack-using-linked-list) — `stack-LL-un-opimise.js`
+3. [Queue using Array (circular)](#3-queue-using-array-circular) — `queue-arr.js`
+4. [Deque (Double-Ended Queue)](#4-deque-double-ended-queue) — `slidingWindowMaximum.js` (skeleton)
+
+**Problems (applications)**
+5. [Balanced Parentheses](#5-balanced-parentheses) — `balancedParantheses.js`
+6. [Next Greater Element (+ Circular)](#6-next-greater-element--circular) — `nge.js`
+7. [Trapping Rain Water](#7-trapping-rain-water) — `trappingRainWater.js`
+8. [Sliding Window Maximum](#8-sliding-window-maximum) — `slidingWindowMaximum.js`
+9. [Celebrity Problem](#9-celebrity-problem) — `celebrityProblem.js`
+
+---
+
+## Data Structures
+
+### 1. Stack using Array
+**File:** `stack-arr.js`
+
+**What:** LIFO structure backed by a plain JS array, capped at `maxsize`. This is the reusable `Stack` exported and used by the parentheses / NGE problems.
+
+**Key operations**
+- `push(ele)` — append at end (only if not full).
+- `pop()` — `splice` off the last element and return it.
+- `top()` — read last element without removing.
+- `isFull` / `isEmpty` — getters comparing `length` to `maxsize` / `0`.
+
+**Strategy:** Array end = top of stack. All ops are O(1) (except `splice`, still effectively O(1) at the tail). Exposed via `module.exports = { Stack }`.
+
+> ⚠️ Note: `isFull`/`isEmpty` are **getters** here (used without `()`), whereas in the linked-list version they are **methods**. Watch this when reusing.
+
+---
+
+### 2. Stack using Linked List
+**File:** `stack-LL-un-opimise.js` (marked "un-optimise")
+
+**What:** Stack built on a singly linked list with `front` and `rear` pointers and a `currSize` counter.
+
+**Key operations**
+- `push` — create `Node`, attach at `rear`, move `rear` forward. Handles the empty case (set both `front` and `rear`).
+- `pop` — **removes from the rear** (the "un-optimised" part): must walk from `front` to find the node whose `next === rear`, making pop **O(n)**. Handles empty and single-element cases.
+- `display` — traverse `front → rear`.
+
+**Strategy:** Because it pushes/pops at the rear of a *singly* linked list, popping needs a full traversal to find the second-to-last node.
+
+**Optimisation idea (why it's "un-optimised"):** Push/pop at the **front** instead → both become O(1) and no traversal needed. (Or use a doubly linked list to pop from rear in O(1).)
+
+---
+
+### 3. Queue using Array (circular)
+**File:** `queue-arr.js`
+
+**What:** FIFO queue on a fixed-size array using the **circular buffer** technique with `front`, `rear`, and `currSize`.
+
+**Key operations**
+- `enqueue(num)` — write at `rear`, then advance `rear = (rear + 1) % maxSize`. Reject if full.
+- `dequeue()` — read at `front`, null it out, advance `front = (front + 1) % maxSize`. Reject if empty.
+- `isFull` — `currSize === maxSize`; `isEmpty` — `currSize === 0`.
+
+**Strategy:** The modulo wrap-around lets freed slots at the start be reused, so the queue never "runs off the end" of the array. `currSize` is the source of truth for full/empty (avoids the classic ambiguity where `front === rear` could mean either).
+
+**Complexity:** All ops O(1).
+
+---
+
+### 4. Deque (Double-Ended Queue)
+**File:** `slidingWindowMaximum.js` (top comment + `DoubleEndedQueue` skeleton)
+
+**What:** Queue supporting insert/remove at **both** ends — the tool needed for Sliding Window Maximum.
+
+**Intended API**
+- `push_front`, `push_back`, `pop_front`, `pop_back`
+- `top_front`, `top_back`
+
+**Status:** Skeleton only (`Node` + constructor with `front`/`back`/`currSize`; `push_back` is empty). To finish: implement as a **doubly linked list** so all six ops are O(1).
+
+---
+
+## Problems
+
+### 5. Balanced Parentheses
+**File:** `balancedParantheses.js` · **Uses:** array `Stack`
+
+**Problem:** Given a string of brackets `[ ] { } ( )`, check if every opening bracket has a correctly-ordered matching close.
+
+**Strategy (classic stack):**
+1. Scan left → right.
+2. On an **opening** bracket → `push` it.
+3. On a **closing** bracket → check `stack.top()` is the matching opener.
+   - Match → `pop` and continue.
+   - Mismatch (or empty) → return `false` immediately.
+4. At the end, valid only if the stack `isEmpty`.
+
+**Why it works:** The stack enforces LIFO nesting — the most recent unclosed opener must be the first to close.
+
+**Complexity:** O(n) time, O(n) space.
+
+> Improvement: use a `{ ')':'(', ']':'[', '}':'{' }` map instead of three `if` blocks to make it concise and extensible.
+
+---
+
+### 6. Next Greater Element (+ Circular)
+**File:** `nge.js` · **Uses:** array `Stack`
+
+**Problem:** For each element, find the first greater element to its **right**; `-1` if none. Circular variant: the array wraps around.
+
+**Strategy (monotonic stack, right → left):**
+1. Iterate from the **last** index to the first.
+2. Maintain a stack of candidate "greater" elements (kept decreasing from top).
+3. For `arr[i]`:
+   - Stack empty → `nge[i] = -1`.
+   - `top > arr[i]` → `nge[i] = top`.
+   - `top <= arr[i]` → **pop** all elements `<= arr[i]` (they can never be the answer for anything to the left), then the new top (if any) is the answer, else `-1`.
+4. `push(arr[i])` for the elements to its left.
+
+**Circular trick:** Concatenate the array with itself (`[...arr, ...arr]`) and run the same NGE. (In a full solution you'd then take the first `n` results.)
+
+**Why it works:** An element smaller than the current one is useless as a future "next greater" for anything further left, so it's discarded — keeping the stack monotonic and giving amortised O(n).
+
+**Complexity:** O(n) time (each element pushed/popped once), O(n) space.
+
+---
+
+### 7. Trapping Rain Water
+**File:** `trappingRainWater.js`
+
+**Problem:** Given building heights, compute total water trapped between them after rain.
+
+**Key insight:** Water above index `i` = `min(maxToLeft, maxToRight) - height[i]` (only if positive).
+
+**Strategy (prefix-max / suffix-max arrays):**
+1. Build `prefixMax[i]` = tallest bar in `arr[0..i]`.
+2. Build `suffixMax[i]` = tallest bar in `arr[i..n-1]`.
+3. For each `i`, if `arr[i]` is below both, add `min(prefixMax[i], suffixMax[i]) - arr[i]`.
+
+**Complexity:** O(n) time, O(n) space.
+
+> Optimisation: the **two-pointer** approach solves this in O(1) extra space — move the pointer on the smaller side inward, tracking `leftMax`/`rightMax` on the fly.
+
+---
+
+### 8. Sliding Window Maximum
+**File:** `slidingWindowMaximum.js` (strategy in comments; deque WIP)
+
+**Problem:** For every window of size `k`, output the maximum element.
+
+**Strategy (monotonic deque, decreasing):**
+- Keep a deque holding **indices/values** in decreasing order; the **front is always the current window's max**.
+- For each element:
+  1. **Keep the window valid** — drop from the front any index that has slid out of the window.
+  2. **Maintain monotonicity** — pop from the **back** while `back < currElement` (those can never be the max again).
+  3. `push_back` the current element.
+  4. Record `dq.front()` as the answer once the first full window is formed.
+
+**Why a deque:** Both "evict from front" (out of window) and "evict from back" (smaller elements) are needed → double-ended, O(1) each.
+
+**Complexity:** O(n) time (each element enters/leaves the deque once), O(k) space.
+
+---
+
+### 9. Celebrity Problem
+**File:** `celebrityProblem.js` (approach documented; solution outlined)
+
+**Problem:** Given an `n × n` matrix where `M[x][y] = 1` means "x knows y", find the **celebrity** — known by everyone but who knows no one. Return `-1` if none.
+
+**Strategy (two-pointer elimination):**
+- Take `l = 0`, `r = n - 1`.
+- While `l < r`:
+  - If `M[l][r] === 1` → `l` knows `r`, so **`l` can't be the celebrity** → `l++`.
+  - Else (`M[r][l] === 1`, or `l` doesn't know `r`) → **`r` can't be the celebrity** → `r--`.
+- The surviving index `l` is the **candidate**.
+
+**Why it works:** Each comparison eliminates exactly one person, narrowing `n` candidates to 1 in O(n) steps.
+
+**Complete solution reminder:** After finding the candidate, **verify** it — the candidate must know *no one* (its row is all 0s, self excluded) and be known by *everyone* (its column is all 1s, self excluded). Without verification the answer can be wrong when no celebrity exists.
+
+**Complexity:** O(n) elimination + O(n) verification = O(n) time, O(1) space.
+
+---
+
+## Quick Recall Cheat-Sheet
+
+| Problem | Core Tool | Time | Space | One-line trick |
+|---|---|---|---|---|
+| Balanced Parentheses | Stack | O(n) | O(n) | Push opens, match on close, end empty |
+| Next Greater Element | Monotonic stack (R→L) | O(n) | O(n) | Pop all ≤ current, top is answer |
+| Circular NGE | Same + `[...arr, ...arr]` | O(n) | O(n) | Double the array |
+| Trapping Rain Water | Prefix/Suffix max | O(n) | O(n) | `min(Lmax, Rmax) − h[i]` |
+| Sliding Window Max | Monotonic deque | O(n) | O(k) | Front = max; evict stale + smaller |
+| Celebrity Problem | Two pointers | O(n) | O(1) | Eliminate one per step, then verify |
+
+---
+
+## Patterns to Remember
+- **Monotonic stack/deque** → "next/previous greater/smaller" and "window max/min" families.
+- **Prefix/Suffix precompute** → when each index needs info about everything on its left *and* right.
+- **Two-pointer elimination** → when one comparison can rule out a candidate (celebrity, container-with-most-water).
+- **Circular buffer (`% maxSize`)** → fixed-capacity queues without shifting elements.

--- a/packages/react-testing/src/components/striver/stack-queue/asteroidCollision.js
+++ b/packages/react-testing/src/components/striver/stack-queue/asteroidCollision.js
@@ -1,0 +1,52 @@
+const { Stack } = require("./stack-arr");
+
+const arr = [4, 7, 1,1, 2, -3, -7, 17, 15, -16];
+
+const asteroidCollisionFinalState = (arr) => {
+    const n = arr.length;
+    const stack = new Stack(n);
+
+    for(let i=0; i<n; i++) {
+        const asteroidValue = arr[i];
+       
+        if(stack.isEmpty) {
+            stack.push(asteroidValue);
+        } else if(asteroidValue > 0 && stack.top < 0) {
+            // asteroid is positive, stack top is negative
+            // pop while there are negative indices and abs < asteroid
+            while(!stack.isEmpty && stack.top() < 0 && Math.abs(stack.top) < asteroidValue) {
+                stack.pop();
+            }
+            if(!stack.isEmpty && Math.abs(stack.top()) === Math.abs(asteroidValue)) {
+                stack.pop();
+            }
+            if(stack.isEmpty) {
+            stack.push(asteroidValue);
+            }
+        } else if(asteroidValue < 0 && stack.top() < 0) {
+            // asteroid is negative, stack top is neg
+            stack.push(asteroidValue);
+        } else if(asteroidValue > 0 && stack.top() > 0) {
+            // asteroid is positive, stack top is pos
+            stack.push(asteroidValue);
+        } else if(asteroidValue < 0 && stack.top() > 0) {
+            // asteroid is negative, stack top is positive
+            while(!stack.isEmpty && stack.top() > 0 && stack.top() < Math.abs(asteroidValue)) {
+                stack.pop();
+            }
+            if(!stack.isEmpty && Math.abs(stack.top()) === Math.abs(asteroidValue)) {
+                stack.pop();
+            }
+            if(stack.isEmpty) {
+                stack.push(asteroidValue);
+            }
+        } else null;
+    }
+
+    return stack;
+
+};
+
+const ans = asteroidCollisionFinalState(arr);
+
+console.log(ans);

--- a/packages/react-testing/src/components/striver/stack-queue/minStack.js
+++ b/packages/react-testing/src/components/striver/stack-queue/minStack.js
@@ -1,0 +1,74 @@
+class MinStack {
+    constructor(maxSize = 10) {
+        this._stack = [];
+        this.maxSize = maxSize;
+        this.min = 1000;
+    }
+
+    push(element) {
+        // if stack full
+        if(this._stack.length === this.maxSize) return;
+
+        // if stack empty: push and update min
+        if(this._stack.length === 0) {
+            this._stack.push(element);
+            this.min = element;
+            return;
+        }
+
+        // if ele < min: push 2*prevMin - ele to stack and update min
+        if(element < this.min) {
+            this._stack.push(2*element - this.min);
+            this.min = element;
+            return;
+        }
+
+        // ele >min: push element to stack
+        if(element > this.min) {
+            this._stack.push(element);
+        }
+        
+    }
+
+    top() {
+        // if arr.at(-1) < min: it is modified value; top->min and return;
+        if(this._stack.at(-1) < this.min) return this.min;
+
+        // if min < arr.at(-1); then return arr.at(-1)
+        else return this._stack.at(-1);
+    }
+
+    pop() {
+        // pop stack.top element and check
+        const popped = this._stack.pop();
+
+        // if ele < min; it is modified; update min
+        if(popped < this.min) {
+            let prevTop = this.min;
+            this.min = 2 * (this.min) - popped;
+            return prevTop;
+        }
+
+        // if ele > min; do not update min
+        return popped;
+    }
+
+    view() {
+        console.log(this._stack);
+    }
+
+}
+
+const minStack = new MinStack(10);
+
+minStack.push(12);
+// minStack.view();
+minStack.push(15);
+// minStack.view();
+minStack.push(10);
+minStack.view();
+minStack.push(7);
+minStack.view();
+
+minStack.pop();
+minStack.view();

--- a/packages/react-testing/src/components/striver/stack-queue/nge.js
+++ b/packages/react-testing/src/components/striver/stack-queue/nge.js
@@ -38,3 +38,7 @@ const getCircularNge = (arr) => {
 
 const nge = getCircularNge(arr);
 console.log(nge);
+
+module.exports = {
+    getNge
+};

--- a/packages/react-testing/src/components/striver/stack-queue/prev-smallest-element.js
+++ b/packages/react-testing/src/components/striver/stack-queue/prev-smallest-element.js
@@ -32,3 +32,7 @@ const prevSmallerElement = (arr) => {
 
 const ans = prevSmallerElement(arr);
 console.log(ans);
+
+module.exports = { 
+    prevSmallerElement
+}

--- a/packages/react-testing/src/components/striver/stack-queue/prev-smallest-element.js
+++ b/packages/react-testing/src/components/striver/stack-queue/prev-smallest-element.js
@@ -1,0 +1,34 @@
+const Stack = require('./stackDS/stack');
+
+const arr = [4, 5, 2, 10, 8];
+
+const prevSmallerElement = (arr) => {
+    const stack = new Stack();
+    let pse = [];
+    const n = arr.length;
+
+    for(let i=0; i<n; i++) {
+        if(stack.isEmpty()) {
+            pse[i] = -1
+        } else if(stack.top() < arr[i]) {
+            pse[i] = stack.top()
+        } else if(stack.top() >= arr[i]) {
+            while(stack.top() >= arr[i] && !stack.isEmpty()) {
+                stack.pop();
+            }
+            if(stack.isEmpty()) {
+                pse[i] = -1;
+            } else {
+                pse[i] = stack.top();
+            }
+        }
+        else null;
+
+        stack.push(arr[i]);
+    }
+
+    return pse;
+};
+
+const ans = prevSmallerElement(arr);
+console.log(ans);

--- a/packages/react-testing/src/components/striver/stack-queue/pse-nse-indices.js
+++ b/packages/react-testing/src/components/striver/stack-queue/pse-nse-indices.js
@@ -1,7 +1,9 @@
 const arr = [4,4,3,3];
 const Stack = require('./stackDS/stack');
 
-// Get index of next smallest element
+// Get index of next smaller-or-equal element
+// non-strict on purpose: pse is strict, so a subarray with duplicate
+// minimums is counted once, by its leftmost minimum
 const nseIndexes = (arr) => {
     const n = arr.length;
     const st = new Stack(arr.length);
@@ -9,12 +11,12 @@ const nseIndexes = (arr) => {
     for(let i= n-1; i>=0; i--) {
         if(i== n-1) {
             nse[i] = n;
-        } else if(st.top().ele < arr[i]) {
+        } else if(st.top().ele <= arr[i]) {
             // push to stack
             // nse = n
             nse[i] = st.top().i;
-        } else if(st.top().ele >= arr[i]) {
-            while(!st.isEmpty() && st.top().ele >= arr[i]) {
+        } else if(st.top().ele > arr[i]) {
+            while(!st.isEmpty() && st.top().ele > arr[i]) {
                 st.pop();
             }
             if(st.isEmpty()) {

--- a/packages/react-testing/src/components/striver/stack-queue/pse-nse-indices.js
+++ b/packages/react-testing/src/components/striver/stack-queue/pse-nse-indices.js
@@ -1,0 +1,66 @@
+const arr = [4,4,3,3];
+const Stack = require('./stackDS/stack');
+
+// Get index of next smallest element
+const nseIndexes = (arr) => {
+    const n = arr.length;
+    const st = new Stack(arr.length);
+    const nse = [];
+    for(let i= n-1; i>=0; i--) {
+        if(i== n-1) {
+            nse[i] = n;
+        } else if(st.top().ele < arr[i]) {
+            // push to stack
+            // nse = n
+            nse[i] = st.top().i;
+        } else if(st.top().ele >= arr[i]) {
+            while(!st.isEmpty() && st.top().ele >= arr[i]) {
+                st.pop();
+            }
+            if(st.isEmpty()) {
+                nse[i] = n;
+
+            } else {
+                nse[i] = st.top().i;
+
+            }
+        } else null;
+
+        st.push({ele: arr[i], i });
+
+    }
+    return nse;
+}
+
+const pseIndexes = (arr) =>  {
+    const stack = new Stack();
+    let pse = [];
+    const n = arr.length;
+
+    for(let i=0; i<n; i++) {
+        if(stack.isEmpty()) {
+            pse[i] = -1
+        } else if(stack.top().ele < arr[i]) {
+            pse[i] = stack.top().i
+        } else if(stack.top().ele >= arr[i]) {
+            while(!stack.isEmpty() && stack.top().ele >= arr[i]) {
+                stack.pop();
+            }
+            if(stack.isEmpty()) {
+                pse[i] = -1;
+            } else {
+                pse[i] = stack.top().i;
+            }
+        }
+        else null;
+
+        stack.push({ ele: arr[i], i });
+    }
+
+    return pse;
+};
+
+module.exports = {
+    pseIndexes,
+    nseIndexes
+};

--- a/packages/react-testing/src/components/striver/stack-queue/stackDS/stack.js
+++ b/packages/react-testing/src/components/striver/stack-queue/stackDS/stack.js
@@ -1,4 +1,4 @@
-export default class Stack {
+class Stack {
     constructor(maxSize = 10) {
         this.maxSize = maxSize;
         this.stack = [];
@@ -24,4 +24,10 @@ export default class Stack {
 
         return this.stack[this.stack.length - 1];
     }
+
+    isEmpty() {
+        return this.stack.length === 0;
+    }
 };
+
+module.exports = Stack;

--- a/packages/react-testing/src/components/striver/stack-queue/stackDS/stack.js
+++ b/packages/react-testing/src/components/striver/stack-queue/stackDS/stack.js
@@ -1,0 +1,27 @@
+export default class Stack {
+    constructor(maxSize = 10) {
+        this.maxSize = maxSize;
+        this.stack = [];
+    }
+
+    push(element) {
+        // if stack full; abort
+        if(this.stack.length === this.maxSize) return;
+        // push element
+        this.stack.push(element);
+    }
+
+    pop() {
+        // if stack empty; abort
+        if(this.stack.length === 0) return;
+
+        // pop top element
+        return this.stack.pop();
+    }
+
+    top() {
+        if(this.stack.size === 0) return -1;
+
+        return this.stack[this.stack.length - 1];
+    }
+};

--- a/packages/react-testing/src/components/striver/stack-queue/sumOfSubarrayMinimum.js
+++ b/packages/react-testing/src/components/striver/stack-queue/sumOfSubarrayMinimum.js
@@ -1,0 +1,20 @@
+const { pseIndexes, nseIndexes } = require("./pse-nse-indices");
+
+const arr = [3, 1, 2, 4];
+
+const sumOfSubArrayMin = (arr) => {
+    let sum = 0;
+    let nse, pse;
+    const n = arr.length;
+
+    pse = pseIndexes(arr);
+    nse = nseIndexes(arr);
+
+    for(let i = 0; i<n; i++) {
+        sum += (i-pse[i])*(nse[i] - i) * arr[i];
+    }
+    return sum;
+};
+
+const ans = sumOfSubArrayMin(arr);
+console.log(ans);

--- a/packages/react-testing/src/components/striver/stack-queue/trappingRainWater.js
+++ b/packages/react-testing/src/components/striver/stack-queue/trappingRainWater.js
@@ -1,7 +1,8 @@
 // if the height of various buildings are represented as numbers in an array
 // Calculate the total water that can be stored between the buildings.
 
-const heights = [1, 0, 3, 0, 3, 0, 1];
+// const heights = [1, 0, 3, 0, 3, 0, 1];
+const heights= [0, 1, 0, 2, 1, 0, 1, 3, 2, 1, 2, 1];
 
 const min = (a, b) => a > b ? b: a;
 

--- a/packages/react-testing/src/index.js
+++ b/packages/react-testing/src/index.js
@@ -69,7 +69,6 @@ function App() {
                 style={{
                     display: "flex",
                     justifyContent: "center",
-                    alignItems: "center",
                     height: "100vh",
                 }}
             >


### PR DESCRIPTION
## Summary
- Add PopoverHTMLApi component demonstrating native HTML Popover API
- Replace default Popover export with HTML API implementation
- Add Accordion practice component with expand/collapse functionality
- Add Toggle/Switch practice component
- Add Permutation generator recursion exercise
- Swap popover for accordion in tutorial component
- Add subsequence and unique subset recursion exercises

## Test Plan
- [ ] Navigate to the practice components
- [ ] Test Popover: Click trigger to open, verify position, close properly
- [ ] Test Accordion: Click to expand/collapse, verify animations
- [ ] Test Toggle: Toggle the switch and verify state changes
- [ ] Test Permutations: Verify all permutations are generated correctly
- [ ] Verify no console errors
- [ ] Check accessibility (aria labels, keyboard navigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)